### PR TITLE
Fix installation via zkg

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -1,3 +1,3 @@
 [package]
-scripts_dir = scripts/tenzir/mac-ages
+script_dir = scripts/tenzir/mac-ages
 tags = conn, mac


### PR DESCRIPTION
The metadata file had a typo that caused a silent failure with `zkg install tenzir/zeek-mac-ages`.